### PR TITLE
Fix: Filters reviews data

### DIFF
--- a/src/api/reviews/reviews.service.ts
+++ b/src/api/reviews/reviews.service.ts
@@ -116,8 +116,8 @@ export class ReviewsService {
       .aggregate([
         { $match: queryFilters },
         { $sort: { createdAt: -1 } },
-        { $skip: (page - 1) * limit },
-        { $limit: limit },
+        { $skip: (page - 1) * Number(limit) },
+        { $limit: Number(limit) },
         {
           $lookup: {
             from: 'reviewstaggeds',

--- a/src/schemas/reviews.schema.ts
+++ b/src/schemas/reviews.schema.ts
@@ -55,7 +55,6 @@ export class Reviews extends Document {
   })
   rating: Number;
 
-
   @Prop({
     type: Number,
     required: true,


### PR DESCRIPTION
# 🚀 PR Title

**Fix for type handling in pagination logic**

## 📖 Description

- **What’s changing?**  
  Updated the pagination logic in the `ReviewsService` to correctly handle the `limit` as a number.

- **Why?**  
  The current implementation potentially caused issues if `limit` was not explicitly handled as a number, leading to incorrect skipping and limiting of reviews in pagination.

## 🛠 Implementation Details

- Adjusted the `$skip` and `$limit` stages in the aggregation pipeline to use `Number(limit)` for ensuring numerical operations.
- Removed an unnecessary blank line in the `reviews.schema.ts` for code style consistency.

## 📊 Queries changed
- Modified the pagination query in `ReviewsService` to properly handle `limit` as a number, affecting how reviews are fetched and displayed.

## ⚙️ New envs
None.

## 🔗 Related Issues / Tickets
None.