### PR TITLE
Refactor: Block review delete before delete map marker

### DIFF
--- a/src/api/map-markers/map-markers.module.ts
+++ b/src/api/map-markers/map-markers.module.ts
@@ -1,21 +1,23 @@
 import { MongooseModule } from '@nestjs/mongoose';
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 
 import { MapMarkersSchema } from 'src/schemas';
 
 import { MapMarkersService } from './map-markers.service';
 import { MapMarkersController } from './map-markers.controller';
 import { ReviewsModule } from '../reviews/reviews.module';
+import { APP_GUARD } from '@nestjs/core';
+import { RolesGuard } from '../auth/roles/roles.guard';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: 'MapMarkers', schema: MapMarkersSchema },
     ]),
-    ReviewsModule,
+    forwardRef(() => ReviewsModule),
   ],
   controllers: [MapMarkersController],
-  providers: [MapMarkersService],
+  providers: [MapMarkersService, { provide: APP_GUARD, useClass: RolesGuard }],
   exports: [MapMarkersService],
 })
 export class MapMarkersModule {}

--- a/src/api/reviews/reviews.module.ts
+++ b/src/api/reviews/reviews.module.ts
@@ -1,5 +1,6 @@
 import { MongooseModule } from '@nestjs/mongoose';
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 
 import { ReviewsService } from './reviews.service';
 import { ReviewsController } from './reviews.controller';
@@ -7,7 +8,10 @@ import { ReviewsController } from './reviews.controller';
 import { ReviewsSchema } from 'src/schemas/reviews.schema';
 import { UsersSchema } from 'src/schemas';
 import { ReviewsTaggedsSchema } from 'src/schemas/reviews-tagged.schema';
+
+import { MapMarkersModule } from '../map-markers/map-markers.module';
 import { TagsModule } from '../tags/tags.module';
+import { RolesGuard } from '../auth/roles/roles.guard';
 
 @Module({
   imports: [
@@ -17,9 +21,10 @@ import { TagsModule } from '../tags/tags.module';
       { name: 'Users', schema: UsersSchema },
     ]),
     TagsModule,
+    forwardRef(() => MapMarkersModule),
   ],
   controllers: [ReviewsController],
-  providers: [ReviewsService],
+  providers: [ReviewsService, { provide: APP_GUARD, useClass: RolesGuard }],
   exports: [ReviewsService],
 })
 export class ReviewsModule {}

--- a/src/api/tags/tags.module.ts
+++ b/src/api/tags/tags.module.ts
@@ -1,15 +1,18 @@
 import { MongooseModule } from '@nestjs/mongoose';
+import { APP_GUARD } from '@nestjs/core';
 import { Module } from '@nestjs/common';
 
 import { TagsService } from './tags.service';
 import { TagsController } from './tags.controller';
+
+import { RolesGuard } from '../auth/roles/roles.guard';
 
 import { TagsSchema } from 'src/schemas/tags.schema';
 
 @Module({
   imports: [MongooseModule.forFeature([{ name: 'Tags', schema: TagsSchema }])],
   controllers: [TagsController],
-  providers: [TagsService],
+  providers: [TagsService, { provide: APP_GUARD, useClass: RolesGuard }],
   exports: [TagsService],
 })
 export class TagsModule {}

--- a/src/api/users/users.module.ts
+++ b/src/api/users/users.module.ts
@@ -1,4 +1,5 @@
 import { MongooseModule } from '@nestjs/mongoose';
+import { APP_GUARD } from '@nestjs/core';
 import { Module } from '@nestjs/common';
 
 import { UsersSchema } from 'src/schemas';
@@ -6,12 +7,14 @@ import { UsersSchema } from 'src/schemas';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
+import { RolesGuard } from '../auth/roles/roles.guard';
+
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: 'Users', schema: UsersSchema }]),
   ],
   controllers: [UsersController],
-  providers: [UsersService],
+  providers: [UsersService, { provide: APP_GUARD, useClass: RolesGuard }],
   exports: [UsersService],
 })
 export class UsersModule {}


### PR DESCRIPTION
# 🚀 Update MapMarkers, Reviews, and Related Services for Enhanced Features

**Short description of the change.**

## 📖 Description

- **What’s changing?**  
  This pull request enhances the `map-markers`, `reviews`, `tags`, and `users` modules by incorporating role-based access control and updating the handling and lifecycle of map markers linked to reviews.

- **Why?**  
  The PR adds new features to support more robust permission handling within the application and optimizes the relationship and operations between maps and reviews.

## 🛠 Implementation Details

- Added `RolesGuard` as a global provider in `map-markers`, `reviews`, `tags`, and `users` modules for role-based access control on services.
- Modified `map-markers` and `reviews` services to use `forwardRef` for module imports to handle circular dependencies.
- Changed the deletion functionality in `MapMarkersService` to a soft-delete model by updating the document with a flag (`isDeleted: true`) instead of removing it.
- Integrated a new method `findByReviewId` in `MapMarkersService` to provide association checks between markers and reviews.
- Implemented logic to prevent the deletion of reviews if linked to existing map markers, returning informative exceptions.
- Refined exception handling in the `ReviewsService` to throw exceptions for not found items and permission checks.

## 📊 Queries changed

- Introduced a new query to find map markers by review ID.
- Updated several existing queries to integrate soft-deletion and exception handling.

## ⚙️ New envs

None.

## 🔗 Related Issues / Tickets

- This update addresses feature requests for enhancing security and data integrity management across linked entities.