### PR TITLE
Chore: Return id when map marker was created

### DIFF
--- a/src/api/map-markers/map-markers.service.ts
+++ b/src/api/map-markers/map-markers.service.ts
@@ -33,7 +33,9 @@ export class MapMarkersService {
   ) {}
 
   @HttpCode(HttpStatus.CREATED)
-  async createMarker(payload: CreateMapMarkerDto): Promise<ITextResponse> {
+  async createMarker(
+    payload: CreateMapMarkerDto,
+  ): Promise<ITextResponse | IDataResponse> {
     const review = await this.reviewsService.findOne(payload.reviewId, '_id');
 
     if (review.statusCode !== HttpStatus.OK) {
@@ -50,13 +52,17 @@ export class MapMarkersService {
     const savedMapMarker = await newMapMarker.save();
 
     if (!savedMapMarker) {
-      return {
-        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-        message: 'Error creating map marker',
-      };
+      throw new BadRequestException('Error creating map marker');
     }
 
-    return textResponse('Map marker created successfully', HttpStatus.CREATED);
+    return dataResponse(
+      {
+        _id: savedMapMarker._id,
+      },
+      1,
+      'Map marker created successfully',
+      HttpStatus.CREATED,
+    );
   }
 
   @HttpCode(HttpStatus.OK)


### PR DESCRIPTION
# 🚀 Improve Map Marker Creation Response

**Short description of the change.**

## 📖 Description

- **What’s changing?**  
  Updated the `createMarker` function within `MapMarkersService` to improve error handling and enhance response payloads.

- **Why?**  
  To provide clearer responses and handle errors more appropriately, improving the service's reliability and client-side interactions.

## 🛠 Implementation Details

- Changed the return type of `createMarker` to allow for both `ITextResponse` and `IDataResponse`, accommodating a more detailed response.
- Replaced a `return` statement in the failure scenario with a `BadRequestException` to align with error handling best practices.
- Expanded successful creation responses to include the new map marker's `_id`, thus offering more information about the created resource.

## 📊 Queries changed

None.

## ⚙️ New envs

None.

## 🔗 Related Issues / Tickets

None.