### PR TITLE
Chore: Return Id when tag was created

### DIFF
--- a/src/api/tags/tags.service.ts
+++ b/src/api/tags/tags.service.ts
@@ -14,6 +14,7 @@ import { Tags } from 'src/schemas/tags.schema';
 import {
   dataResponse,
   dataResponseWithPagination,
+  IDataResponse,
   IDataResponseWithPagination,
   ITextResponse,
   textResponse,
@@ -29,13 +30,20 @@ export class TagsService {
   ) {}
 
   @HttpCode(HttpStatus.CREATED)
-  async create(payload: CreateTagDto): Promise<ITextResponse> {
+  async create(payload: CreateTagDto): Promise<IDataResponse | ITextResponse> {
     const newTag = new this.tagsModel({
       ...payload,
     });
 
-    await newTag.save();
-    return textResponse('Tag created successfully', HttpStatus.CREATED);
+    const newTagQueryResponse = await newTag.save();
+    return dataResponse(
+      {
+        _id: newTagQueryResponse._id,
+      },
+      1,
+      'Tag created successfully',
+      HttpStatus.CREATED,
+    );
   }
 
   @HttpCode(HttpStatus.OK)


### PR DESCRIPTION
# 🚀 Enhanced Tag Creation Response

**Short description of the change.**  
Updated the `create` method in `TagsService` to return more detailed response data upon creating a tag.

## 📖 Description

- **What’s changing?**  
  The `create` method within the `TagsService` now returns an `IDataResponse` that includes the ID of the newly created tag along with the original text message.

- **Why?**  
  This change improves the functionality by providing the client with immediate access to the `_id` of the created tag, which can enhance subsequent interactions or operations related to the tag creation process.

## 🛠 Implementation Details

- Updated the method signature of `create` from `Promise<ITextResponse>` to `Promise<IDataResponse | ITextResponse>`.
- Modified the return value to include a structured data response using `dataResponse`, which encapsulates the tag ID and success message.

## 📊 Queries changed

- No database queries were changed; however, the response structure has been enhanced to include `_id` of the newly created tag.

## ⚙️ New envs

- None.

## 🔗 Related Issues / Tickets

- None.