### PR TITLE
Fix: Duplicate error entry alerts

### DIFF
--- a/src/api/tags/tags.service.ts
+++ b/src/api/tags/tags.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   HttpCode,
   HttpException,
   HttpStatus,
@@ -31,6 +32,12 @@ export class TagsService {
 
   @HttpCode(HttpStatus.CREATED)
   async create(payload: CreateTagDto): Promise<IDataResponse | ITextResponse> {
+    const existingTag = await this.tagsModel.findOne({ name: payload.name });
+
+    if (existingTag) {
+      throw new BadRequestException('Tag already exists');
+    }
+
     const newTag = new this.tagsModel({
       ...payload,
     });


### PR DESCRIPTION
# 🚀 Fix: Duplicate error entry alerts

Add Duplicate Tag Validation to `create` Method in `TagsService`

## 📖 Description

- **What’s changing?**  
  Added validation to check for duplicate tags in the `create` method of `TagsService`.

- **Why?**  
  To prevent the creation of duplicate tags, ensuring data integrity within the application.

## 🛠 Implementation Details

- Added a check in the `create` method to see if a tag with the same name already exists in the database.
- Threw a `BadRequestException` if a duplicate tag is found, with the message "Tag already exists".

## 📊 Queries changed
- Introduced a query to check for an existing tag by name before creating a new one.

## ⚙️ New envs
none.

## 🔗 Related Issues / Tickets
none.