### PR TITLE
Refactor: Allow upload and delete multiple images

### DIFF
--- a/src/api/images/dto/delete-multiple-images.dto.ts
+++ b/src/api/images/dto/delete-multiple-images.dto.ts
@@ -1,0 +1,8 @@
+import { IsArray, IsNotEmpty, IsString } from "class-validator";
+
+export class DeleteMultipleImagesDto {
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty()
+  ids: string[];
+}

--- a/src/api/images/images.controller.ts
+++ b/src/api/images/images.controller.ts
@@ -10,6 +10,7 @@ import {
   Delete,
   Param,
   BadGatewayException,
+  Body,
 } from '@nestjs/common';
 
 import { imageFileFilter } from 'src/utils/images';
@@ -20,6 +21,7 @@ import { RolesGuard } from '../auth/roles/roles.guard';
 import { Roles } from '../auth/roles/roles.decorator';
 
 import { ImagesService } from './images.service';
+import { DeleteMultipleImagesDto } from './dto/delete-multiple-images.dto';
 
 @Controller('images')
 export class ImagesController {
@@ -29,24 +31,24 @@ export class ImagesController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(ERole.admin)
   @UseInterceptors(
-    FilesInterceptor('image', 1, { fileFilter: imageFileFilter }),
+    FilesInterceptor('image', 12, { fileFilter: imageFileFilter }),
   )
   @Post()
   upload(@UploadedFiles() file: Array<Express.Multer.File>) {
-    const image = [];
+    const images = [];
 
     if (!file || !file.length) {
       throw new BadGatewayException('Image is required!');
     }
 
     file.forEach((e) => {
-      image.push({
+      images.push({
         buffer: e.buffer,
         filename: e.originalname,
       });
     });
 
-    return this.imagesService.upload(image[0]);
+    return this.imagesService.upload(images);
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)
@@ -54,5 +56,12 @@ export class ImagesController {
   @Delete(':id')
   deleteImage(@Param('id') id: string) {
     return this.imagesService.delete(id);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(ERole.admin)
+  @Delete()
+  deleteMultipleImages(@Body() payload: DeleteMultipleImagesDto) {
+    return this.imagesService.deleteMultiple(payload.ids);
   }
 }

--- a/src/api/images/images.service.ts
+++ b/src/api/images/images.service.ts
@@ -6,7 +6,7 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 
 import {
   dataResponse,
@@ -26,28 +26,48 @@ export class ImagesService {
   ) { }
 
   @HttpCode(HttpStatus.CREATED)
-  async upload(image: {
+  async upload(images: {
     buffer: Buffer<ArrayBufferLike>;
     filename: string;
-  }): Promise<IDataResponse | ITextResponse> {
-    const uploadImageResult = await uploadImageS3({
-      file: image,
-      ACL: 'public-read',
-    });
+  }[]): Promise<IDataResponse | ITextResponse> {
+    const responses = await Promise.all(images.map(async (image) => {
+      const uploadImageResult = await uploadImageS3({
+        file: image,
+        ACL: 'public-read',
+      });
 
-    const newImage = new this.imagesModel({
-      path: uploadImageResult.Location,
-      filename: uploadImageResult.Key,
-      alt: uploadImageResult.Key.split('.').slice(0, -1).join('.'),
-    });
+      return uploadImageResult;
+    }));
 
-    const newImageQueryResponse = await newImage.save();
+
+    const imagesInserted = await Promise.all(responses.map(async (response) => {
+      const newImage = new this.imagesModel({
+        path: response.Location,
+        filename: response.Key,
+        alt: response.Key.split('.').slice(0, -1).join('.'),
+      });
+
+      return { _id: (await newImage.save())._id, path: response.Location };
+    }));
+
+
+    let response: { _id: string, url: string } | { _id: string, url: string }[];
+
+    if (imagesInserted.length === 1) {
+      response = {
+        _id: imagesInserted[0]._id as string,
+        url: imagesInserted[0].path,
+      }
+    } else {
+      response = imagesInserted.map((image) => ({
+        _id: image._id as string,
+        url: image.path,
+      }));
+    }
+
 
     return dataResponse(
-      {
-        _id: newImageQueryResponse._id,
-        url: uploadImageResult.Location,
-      },
+      response,
       1,
       'Image created successfully',
       HttpStatus.CREATED,
@@ -64,6 +84,28 @@ export class ImagesService {
 
       await deleteFileS3({ key: image.filename });
       await this.imagesModel.deleteOne({ _id: id }).exec();
+
+      return textResponse('Image deleted successfully!', HttpStatus.OK);
+    } catch (error) {
+      throw new HttpException(error.message, error.status);
+    }
+  }
+
+  @HttpCode(HttpStatus.OK)
+  async deleteMultiple(ids: string[]) {
+    try {
+      const idsConvertedToObjectId = ids.map((id) => new Types.ObjectId(id));
+
+      const images = await this.imagesModel.find({ _id: { $in: idsConvertedToObjectId } });
+      if (images.length !== ids.length) {
+        throw new BadRequestException('Error fetching images, some images not found!');
+      }
+
+      await Promise.all(images.map(async (image) => {
+        await deleteFileS3({ key: image.filename });
+      }));
+
+      await this.imagesModel.deleteMany({ _id: { $in: idsConvertedToObjectId } }).exec();
 
       return textResponse('Image deleted successfully!', HttpStatus.OK);
     } catch (error) {


### PR DESCRIPTION
# 🚀 Add Support for Deleting Multiple Images

**Short description of the change.**

## 📖 Description

- **What’s changing?**  
  This pull request introduces functionality to delete multiple images at once and refactors the existing image upload logic to support multiple file uploads simultaneously.

- **Why?**  
  This feature reduces the need to delete images one by one, making the process more efficient and user-friendly. The refactoring also supports improved management of bulk image uploads.

## 🛠 Implementation Details

- Introduced a new DTO (`DeleteMultipleImagesDto`) to handle the payload for deleting multiple images.
- Updated the `ImagesController` to include a new endpoint, `deleteMultipleImages`, which accepts a list of image IDs for deletion.
- Enhanced the `upload` method in `ImagesService` to handle and store multiple images from the `FilesInterceptor`.
- Implemented a `deleteMultiple` method in the `ImagesService` to:
  - Validate the existence of images before deletion.
  - Delete images from both the database and AWS S3.
- Included validation to ensure non-empty arrays of string IDs for deletion requests.

## 📊 Queries changed

- The query in the `deleteMultiple` method to retrieve and delete images based on multiple IDs was added.

## ⚙️ New envs

- None.

## 🔗 Related Issues / Tickets

- None.