### PR TITLE
Chore: Return _id when review was created

### DIFF
--- a/src/api/reviews/reviews.service.ts
+++ b/src/api/reviews/reviews.service.ts
@@ -47,7 +47,7 @@ export class ReviewsService {
 
     @Inject(forwardRef(() => MapMarkersService))
     private readonly mapMarkerService: MapMarkersService,
-  ) {}
+  ) { }
 
   @HttpCode(HttpStatus.CREATED)
   async createReview(payload: CreateReviewDto, auth: string) {
@@ -92,6 +92,7 @@ export class ReviewsService {
 
     return dataResponse(
       {
+        _id: newReviewId,
         friendlyUrl,
         createdAt: dayjs().format('YYYY-MM-DD'),
       },
@@ -214,17 +215,17 @@ export class ReviewsService {
           $project: {
             ...(fields
               ? fields.split(' ').reduce((acc, field) => {
-                  acc[field] = 1;
-                  return acc;
-                }, {})
+                acc[field] = 1;
+                return acc;
+              }, {})
               : {
-                  isDeleted: 0,
-                  tagsInfo: 0,
-                  __v: 0,
-                  'tags.__v': 0,
-                  'tags.createdAt': 0,
-                  'tags.updatedAt': 0,
-                }),
+                isDeleted: 0,
+                tagsInfo: 0,
+                __v: 0,
+                'tags.__v': 0,
+                'tags.createdAt': 0,
+                'tags.updatedAt': 0,
+              }),
           },
         },
       ])


### PR DESCRIPTION
# 🚀 Improve ReviewsService Code Consistency and Data Response

**Short description of the change.**

## 📖 Description

- **What’s changing?**  
  This PR includes minor formatting adjustments and an enhancement to the data response object in the `ReviewsService`.

- **Why?**  
  The changes aim to improve code consistency and ensure that newly created reviews have their IDs included in the response, aiding in better data tracking and interaction with the frontend.

## 🛠 Implementation Details

- Reformatted constructor of `ReviewsService` for consistency by adjusting whitespace.
- Enhanced the `createReview` method's response object to include `_id` for better identification of newly created reviews.
- Reformatted `$project` function in the aggregation query for improved readability and consistency with existing code style.

## 📊 Queries changed

- Modified the return value of the aggregation query to ensure consistent projection handling.

## ⚙️ New envs

- None

## 🔗 Related Issues / Tickets

- None